### PR TITLE
Reintroduce envar

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 # LoCo Linux
 
-This repository is adapted from the Kubos linux configuration (https://github.com/kubos/kubos-linux-build).  It contains an external configuration for Buildroot (https://buildroot.org/) that creates a disk image containing linux and the U-Boot loader for the Pumpkin MBM2 based on the BeagleBone Black single board computer.  
+This repository is adapted from the Kubos linux configuration (https://github.com/kubos/kubos-linux-build).  It contains an external configuration for Buildroot (https://buildroot.org/) that creates a disk image containing linux and the U-Boot loader for the Pumpkin MBM2 based on the BeagleBone Black single board computer.
 
 The disk and linux image it creates is configured as follows:
 * Disk Contents:
     * Master boot record (MBR):  Contains partuuid and partition table
-    * Parittion 1 (~16 MB): Boot (U-Boot binary, linux kernel binary, flattened device tree)
+    * Partition 1 (~16 MB): Boot (U-Boot binary, linux kernel binary, flattened device tree)
     * Partition 2 (~64 MB): Linux root filesystem (mounted as "/")
-    * Partition 3 (~256 MB): U-Boot upgrade (*.itb) and environment storage (mounted as "/upgrade")
-    * Partition 4 (~3000 MB): Rest of disk as ext4 (mounted as "/home")
-    * NOTE: We've limited the number of partitions to four so that they are all primary partitions.  More than four requires the use of logical partitions.  It isn't a big deal, but this makes resizing the "/home" partition to fit the disk easier during installation.
+    * Partition 3 (2M): U-Boot environment variable storage.
+    * Partition 4: Logical partition which encapsulates partitions 5 and 6
+    * Partition 5 (~256 MB): U-Boot upgrade (*.itb) and environment storage (mounted as "/upgrade")
+    * Partition 6 (~3000 MB): Rest of disk as ext4 (mounted as "/home")
+    * NOTE: More than four requires the use of logical partitions.  It isn't a big deal, but this makes resizing the "/home" partition to fit the disk easier during installation.
 * U-Boot
     * Configuration is identical to Kubos version (github.com/kubos/uboot) initially and will be modified for desired behavior soon.
-* Linux 
-    * Kernel 4.19
+* Linux
+    * Kernel 5.4
     * User accounts:  The only user account is "root", which has no password
     * BusyBox provides most of the standard command line functions, but some additional executables are included (e.g. parted)
     * The BeagleBone will appear as a USB ethernet adapter when connected to host computer by USB.  The USB ethernet interface is configured with a static IP address: 192.168.7.2
@@ -24,7 +26,7 @@ The disk and linux image it creates is configured as follows:
     * Root filesystem contains key configurations:
         * /etc/default/dropbear: Configuration file to allow root login over SSH without password
         * /etc/dropbear/dropbear_ecdsa_host_key: Default SSH host key so it doesn't change each time loco-linux is installed
-        * /etc/fstab.mmc*: Template mount tables for installation on mmc0 or mmc1.  One of these is copied to /etc/fstab during installation. 
+        * /etc/fstab.mmc*: Template mount tables for installation on mmc0 or mmc1.  One of these is copied to /etc/fstab during installation.
         * /etc/inittab: Configuration of init, which runs during startup and performs disk checks and other operations before monit is started
         * /etc/init.d:  Startup and shutdown scripts, e.g, Kubos script needed for tracking U-boot upgrade status, script that disables the user LEDs on startup, etc.
         * /etc/monitrc: Configuration of monit to manage services
@@ -40,24 +42,24 @@ The intent of loco-linux is to be able provide a redundant system with essential
 
 Each of these changes can be made by setting the optional arguments to the install-os script when it is executed to copy the disk image to the selected device.  NOTE:  Currently, U-Boot doesn't support completely independent operation.  It always tries to read its environment from mmc1, regardless of which device was used by the processor for startup.  We intend to modify U-Boot to correct this behavior.
 
-## Installation 
+## Installation
 
 Download this repository by cloning it with git:
 
     $ git clone https://github.com/ASU-cubesat/loco-linux.git
-    
+
 Change directories to go inside loco-linux and run the setup script.  The setup script requires the board name as a command line argument and accepts several options.  Use ./setup.sh -h for details.  Typically, it is called as:
 
     $ cd loco-linux
     $ ./setup.sh -d -c pumpkin-mbm2
-    
+
 This will automatically download Buildroot and install it in the parent directory above loco-linux and add the loco-linux git hash to the compiled linux distribution (accessible at /proc/version on the target).   The only board currently supported is the pumpkin-mbm2.   The script regitsters the loco-linux directory with Buildroot using Buildroot's BR2_EXTERNAL make argument.
 
 To start the build, change directories into Buildroot and call make:
 
     $ cd ../buildroot-2022.02.3/
     $ make
-    
+
 Buildroot will download all needed packages and compile.  The process can be lengthy and may take many minutes.
 
 ## Output
@@ -65,13 +67,13 @@ Buildroot will download all needed packages and compile.  The process can be len
 The principal output when the build completes will be in:
 
     buildroot-2022.02.3/output/images
-    
+
 Several files will be in this directory, but the three main output files are:
 
 * os.img: Uncompressed disk image suitable for installing on an bootable (micro)SD card that can be used in the target device.
 * os.img.gz: Compressed disk image suitable for copying to the target device and installing from an already running system.
-* system.itb: Compressed partial disk image used by U-Boot to upgrade the boot (p1) and root filesystem (p2) partitions.  This can be copied to the upgrade partition (p3) of a target device that already has loco-linux running.  U-boot can then be used to install the upgrade.  
-    
+* system.itb: Compressed partial disk image used by U-Boot to upgrade the boot (p1) and root filesystem (p2) partitions.  This can be copied to the upgrade partition (p3) of a target device that already has loco-linux running.  U-boot can then be used to install the upgrade.
+
 ## Installing onto the Pumpkin-MBM2 / BeagleBone
 
 ### Method 1: Bootable micro-SD card
@@ -82,44 +84,43 @@ Several files will be in this directory, but the three main output files are:
 3. Enter the following:
 
         $ setenv bootargs console=ttyS0,115200 root=/dev/mmcblk0p2 ext4 rootwait; fatload mmc 0:1 ${fdtaddr} /pumpkin-mbm2.dtb; fatload mmc 0:1 ${loadaddr} /kernel; bootm ${loadaddr} - ${fdtaddr}
-    
-4. Enter "reset" to reboot 
-5. loco-linux should boot up, running from the micro-SD card (mmc0).  
-6. You should see the linux user prompt.  Enter "root".  There is no password.
-7. After loggin in, the final step is to install loco-linux on the internal flash (mmc1): 
 
-        $ install-os -i /dev/mmcblk0 -o 1 -d -r 
-        
+4. Enter "reset" to reboot
+5. loco-linux should boot up, running from the micro-SD card (mmc0).
+6. You should see the linux user prompt.  Enter "root".  There is no password.
+7. After loggin in, the final step is to install loco-linux on the internal flash (mmc1):
+
+        $ install-os -i /dev/mmcblk0 -o 1 -d -r
+
 8. Reboot to the internal flash (mmc1). Hold space while rebooting to drop into the U-Boot terminal then execute:
 
         $ setenv bootargs console=ttyS0,115200 root=/dev/mmcblk1p2 ext4 rootwait; fatload mmc 1:1 ${fdtaddr} /pumpkin-mbm2.dtb; fatload mmc 1:1 ${loadaddr} /kernel; bootm ${loadaddr} - ${fdtaddr}
-    
+
 9. Run install os again but output to the SD-card
 
-        $ install-os -i /dev/mmcblk1 -o 0 -d -r 
-        
+        $ install-os -i /dev/mmcblk1 -o 0 -d -r
+
     * This fixes the partuuid on the SD card note from step 1 and copies the correct fstab into /etc
 
 ### Method 2: Compressed disk image
 
-If you already have linux (loco-linux or another reasonably functional linux) running on the BeagleBone, you can use the compressed image file to avoid having to use a micro-SD card.  
+If you already have linux (loco-linux or another reasonably functional linux) running on the BeagleBone, you can use the compressed image file to avoid having to use a micro-SD card.
 
 1. Copy os.img.gz to the running linux on the target, make sure it is not on the disk (mmc0 or mmc1) that you want to overwrite.
 2. Run the following, replacing \<target mmc\> with either 0 or 1 for micro-SD card or internal flash, respectively.
-    
-        $ install-os -i ./os.img.gz -o <target mmc> -d -r 
-        
+
+        $ install-os -i ./os.img.gz -o <target mmc> -d -r
+
 ### Method 3: U-Boot upgrade
 
 To upgrade only the boot (partition 1) and root filesystem (partition 2) on an already running loco-linux installation, you can use the system.itb file:
 
 1. Rename the file with a specific version number, e.g. system-1.0.1.itb
-2. Copy the .itb file to the device and place it in /upgrade.  Note that the upgrade parition is fairly small and you made need to delete an existing older system.itb file to make room for the new one.  
+2. Copy the .itb file to the device and place it in /upgrade.  Note that the upgrade parition is fairly small and you made need to delete an existing older system.itb file to make room for the new one.
 3. Set the U-Boot environment to tell it to install the new version on the next reboot:
 
         $ fw_setenv kubos_updatefile system-1.0.1.itb
 
 4. Reboot
-  
-##   
 
+##

--- a/board/pumpkin-mbm2/genimage.cfg
+++ b/board/pumpkin-mbm2/genimage.cfg
@@ -60,6 +60,5 @@ image os.img {
     partition home {
         partition-type = 0x83
         image = "home"
-        # size = 0
     }
 }

--- a/board/pumpkin-mbm2/genimage.cfg
+++ b/board/pumpkin-mbm2/genimage.cfg
@@ -54,11 +54,12 @@ image os.img {
     partition upgrade {
         partition-type = 0x83
         image = "upgrade"
+        size = 356M
     }
 
     partition home {
         partition-type = 0x83
         image = "home"
-        size = 0	
+        # size = 0
     }
 }

--- a/board/pumpkin-mbm2/genimage.cfg
+++ b/board/pumpkin-mbm2/genimage.cfg
@@ -16,9 +16,16 @@ image upgrade {
     mountpoint = "/upgrade"
 }
 
+
+image uboot-envar {
+    ext4 {}
+    size = 2M
+    mountpoint = "/envar"
+}
+
 image home {
     ext4 {}
-    size = 3207MB
+    size = 3105MB
     mountpoint = "/home"
 }
 
@@ -37,7 +44,13 @@ image os.img {
         partition-type = 0x83
         image = "rootfs.ext4"
     }
-        
+
+    partition envar {
+        partition-type = 0x83
+        image = "uboot-envar"
+        size = 2M
+    }
+
     partition upgrade {
         partition-type = 0x83
         image = "upgrade"

--- a/board/pumpkin-mbm2/rootfs_overlay/etc/fstab
+++ b/board/pumpkin-mbm2/rootfs_overlay/etc/fstab
@@ -11,10 +11,10 @@ sysfs		/sys		sysfs	defaults	0	0
 # Define and mount points for both mmc0 and mmc1 partitions
 /dev/mmcblk0p2  /mnt/mmc0           ext4    defaults        0       0
 /dev/mmcblk0p3  /mnt/mmc0/envar   ext4    defaults        0       0
-/dev/mmcblk0p4  /mnt/mmc0/upgrade   ext4    defaults        0       0
-/dev/mmcblk0p5  /mnt/mmc0/home      ext4    defaults        0       0
+/dev/mmcblk0p5  /mnt/mmc0/upgrade   ext4    defaults        0       0
+/dev/mmcblk0p6  /mnt/mmc0/home      ext4    defaults        0       0
 
 /dev/mmcblk1p2  /mnt/mmc1           ext4    defaults        0       0
 /dev/mmcblk1p3  /mnt/mmc1/envar   ext4    defaults        0       0
-/dev/mmcblk1p4  /mnt/mmc1/upgrade   ext4    defaults        0       0
-/dev/mmcblk1p5  /mnt/mmc1/home      ext4    defaults        0       0
+/dev/mmcblk1p5  /mnt/mmc1/upgrade   ext4    defaults        0       0
+/dev/mmcblk1p6  /mnt/mmc1/home      ext4    defaults        0       0

--- a/board/pumpkin-mbm2/rootfs_overlay/etc/fstab
+++ b/board/pumpkin-mbm2/rootfs_overlay/etc/fstab
@@ -10,9 +10,11 @@ sysfs		/sys		sysfs	defaults	0	0
 
 # Define and mount points for both mmc0 and mmc1 partitions
 /dev/mmcblk0p2  /mnt/mmc0           ext4    defaults        0       0
-/dev/mmcblk0p3  /mnt/mmc0/upgrade   ext4    defaults        0       0
-/dev/mmcblk0p4  /mnt/mmc0/home      ext4    defaults        0       0
+/dev/mmcblk0p3  /mnt/mmc0/envar   ext4    defaults        0       0
+/dev/mmcblk0p4  /mnt/mmc0/upgrade   ext4    defaults        0       0
+/dev/mmcblk0p5  /mnt/mmc0/home      ext4    defaults        0       0
 
 /dev/mmcblk1p2  /mnt/mmc1           ext4    defaults        0       0
-/dev/mmcblk1p3  /mnt/mmc1/upgrade   ext4    defaults        0       0
-/dev/mmcblk1p4  /mnt/mmc1/home      ext4    defaults        0       0
+/dev/mmcblk1p3  /mnt/mmc1/envar   ext4    defaults        0       0
+/dev/mmcblk1p4  /mnt/mmc1/upgrade   ext4    defaults        0       0
+/dev/mmcblk1p5  /mnt/mmc1/home      ext4    defaults        0       0

--- a/board/pumpkin-mbm2/rootfs_overlay/etc/fstab.mmc0
+++ b/board/pumpkin-mbm2/rootfs_overlay/etc/fstab.mmc0
@@ -9,16 +9,19 @@ tmpfs		/run		tmpfs	mode=0755,nosuid,nodev	0	0
 sysfs		/sys		sysfs	defaults	0	0
 
 # Mount mmc0 partitions
-/dev/mmcblk0p3  /upgrade            ext4    defaults               0       0
-/dev/mmcblk0p4  /home               ext4    defaults               0       2
+/dev/mmcblk0p3  /envar            ext4    defaults               0       0
+/dev/mmcblk0p4  /upgrade            ext4    defaults               0       0
+/dev/mmcblk0p5  /home               ext4    defaults               0       2
 
 # Define but don't mount points for both mmc0 and mmc1 partitions
 /dev/mmcblk0p1	/mnt/mmc0/boot      vfat    defaults,noauto        0       0
 /dev/mmcblk0p2  /mnt/mmc0           ext4    defaults,noauto        0       0
-/dev/mmcblk0p3  /mnt/mmc0/upgrade   ext4    defaults,noauto        0       0
-/dev/mmcblk0p4  /mnt/mmc0/home      ext4    defaults,noauto        0       0
+/dev/mmcblk0p3  /mnt/mmc0/envar   ext4    defaults,noauto        0       0
+/dev/mmcblk0p4  /mnt/mmc0/upgrade   ext4    defaults,noauto        0       0
+/dev/mmcblk0p5  /mnt/mmc0/home      ext4    defaults,noauto        0       0
 
 /dev/mmcblk1p1	/mnt/mmc1/boot      vfat    defaults,noauto        0       0
 /dev/mmcblk1p2  /mnt/mmc1           ext4    defaults,noauto        0       0
-/dev/mmcblk1p3  /mnt/mmc1/upgrade   ext4    defaults,noauto        0       0
-/dev/mmcblk1p4  /mnt/mmc1/home      ext4    defaults,noauto        0       0
+/dev/mmcblk1p3  /mnt/mmc1/envar   ext4    defaults,noauto        0       0
+/dev/mmcblk1p4  /mnt/mmc1/upgrade   ext4    defaults,noauto        0       0
+/dev/mmcblk1p5  /mnt/mmc1/home      ext4    defaults,noauto        0       0

--- a/board/pumpkin-mbm2/rootfs_overlay/etc/fstab.mmc0
+++ b/board/pumpkin-mbm2/rootfs_overlay/etc/fstab.mmc0
@@ -10,18 +10,18 @@ sysfs		/sys		sysfs	defaults	0	0
 
 # Mount mmc0 partitions
 /dev/mmcblk0p3  /envar            ext4    defaults               0       0
-/dev/mmcblk0p4  /upgrade            ext4    defaults               0       0
-/dev/mmcblk0p5  /home               ext4    defaults               0       2
+/dev/mmcblk0p5  /upgrade            ext4    defaults               0       0
+/dev/mmcblk0p6  /home               ext4    defaults               0       2
 
 # Define but don't mount points for both mmc0 and mmc1 partitions
 /dev/mmcblk0p1	/mnt/mmc0/boot      vfat    defaults,noauto        0       0
 /dev/mmcblk0p2  /mnt/mmc0           ext4    defaults,noauto        0       0
 /dev/mmcblk0p3  /mnt/mmc0/envar   ext4    defaults,noauto        0       0
-/dev/mmcblk0p4  /mnt/mmc0/upgrade   ext4    defaults,noauto        0       0
-/dev/mmcblk0p5  /mnt/mmc0/home      ext4    defaults,noauto        0       0
+/dev/mmcblk0p5  /mnt/mmc0/upgrade   ext4    defaults,noauto        0       0
+/dev/mmcblk0p6  /mnt/mmc0/home      ext4    defaults,noauto        0       0
 
 /dev/mmcblk1p1	/mnt/mmc1/boot      vfat    defaults,noauto        0       0
 /dev/mmcblk1p2  /mnt/mmc1           ext4    defaults,noauto        0       0
 /dev/mmcblk1p3  /mnt/mmc1/envar   ext4    defaults,noauto        0       0
-/dev/mmcblk1p4  /mnt/mmc1/upgrade   ext4    defaults,noauto        0       0
-/dev/mmcblk1p5  /mnt/mmc1/home      ext4    defaults,noauto        0       0
+/dev/mmcblk1p5  /mnt/mmc1/upgrade   ext4    defaults,noauto        0       0
+/dev/mmcblk1p6  /mnt/mmc1/home      ext4    defaults,noauto        0       0

--- a/board/pumpkin-mbm2/rootfs_overlay/etc/fstab.mmc1
+++ b/board/pumpkin-mbm2/rootfs_overlay/etc/fstab.mmc1
@@ -9,16 +9,19 @@ tmpfs		/run		tmpfs	mode=0755,nosuid,nodev	0	0
 sysfs		/sys		sysfs	defaults	0	0
 
 # Mount mmc1 partitions
-/dev/mmcblk1p3  /upgrade            ext4    defaults               0       0
-/dev/mmcblk1p4  /home               ext4    defaults               0       2
+/dev/mmcblk1p3  /envar            ext4    defaults               0       0
+/dev/mmcblk1p4  /upgrade            ext4    defaults               0       0
+/dev/mmcblk1p5  /home               ext4    defaults               0       2
 
 # Define but don't mount points for both mmc0 and mmc1 partitions
 /dev/mmcblk0p1  /mnt/mmc0/boot      vfat    defaults,noauto        0       0
 /dev/mmcblk0p2  /mnt/mmc0           ext4    defaults,noauto        0       0
-/dev/mmcblk0p3  /mnt/mmc0/upgrade   ext4    defaults,noauto        0       0
-/dev/mmcblk0p4  /mnt/mmc0/home      ext4    defaults,noauto        0       0
+/dev/mmcblk0p3  /mnt/mmc0/envar   ext4    defaults,noauto        0       0
+/dev/mmcblk0p4  /mnt/mmc0/upgrade   ext4    defaults,noauto        0       0
+/dev/mmcblk0p5  /mnt/mmc0/home      ext4    defaults,noauto        0       0
 
 /dev/mmcblk1p1  /mnt/mmc1/boot      vfat    defaults,noauto        0       0
 /dev/mmcblk1p2  /mnt/mmc1           ext4    defaults,noauto        0       0
-/dev/mmcblk1p3  /mnt/mmc1/upgrade   ext4    defaults,noauto        0       0
-/dev/mmcblk1p4  /mnt/mmc1/home      ext4    defaults,noauto        0       0
+/dev/mmcblk1p3  /mnt/mmc1/envar   ext4    defaults,noauto        0       0
+/dev/mmcblk1p4  /mnt/mmc1/upgrade   ext4    defaults,noauto        0       0
+/dev/mmcblk1p5  /mnt/mmc1/home      ext4    defaults,noauto        0       0

--- a/board/pumpkin-mbm2/rootfs_overlay/etc/fstab.mmc1
+++ b/board/pumpkin-mbm2/rootfs_overlay/etc/fstab.mmc1
@@ -10,18 +10,18 @@ sysfs		/sys		sysfs	defaults	0	0
 
 # Mount mmc1 partitions
 /dev/mmcblk1p3  /envar            ext4    defaults               0       0
-/dev/mmcblk1p4  /upgrade            ext4    defaults               0       0
-/dev/mmcblk1p5  /home               ext4    defaults               0       2
+/dev/mmcblk1p5  /upgrade            ext4    defaults               0       0
+/dev/mmcblk1p6  /home               ext4    defaults               0       2
 
 # Define but don't mount points for both mmc0 and mmc1 partitions
 /dev/mmcblk0p1  /mnt/mmc0/boot      vfat    defaults,noauto        0       0
 /dev/mmcblk0p2  /mnt/mmc0           ext4    defaults,noauto        0       0
 /dev/mmcblk0p3  /mnt/mmc0/envar   ext4    defaults,noauto        0       0
-/dev/mmcblk0p4  /mnt/mmc0/upgrade   ext4    defaults,noauto        0       0
-/dev/mmcblk0p5  /mnt/mmc0/home      ext4    defaults,noauto        0       0
+/dev/mmcblk0p5  /mnt/mmc0/upgrade   ext4    defaults,noauto        0       0
+/dev/mmcblk0p6  /mnt/mmc0/home      ext4    defaults,noauto        0       0
 
 /dev/mmcblk1p1  /mnt/mmc1/boot      vfat    defaults,noauto        0       0
 /dev/mmcblk1p2  /mnt/mmc1           ext4    defaults,noauto        0       0
 /dev/mmcblk1p3  /mnt/mmc1/envar   ext4    defaults,noauto        0       0
-/dev/mmcblk1p4  /mnt/mmc1/upgrade   ext4    defaults,noauto        0       0
-/dev/mmcblk1p5  /mnt/mmc1/home      ext4    defaults,noauto        0       0
+/dev/mmcblk1p5  /mnt/mmc1/upgrade   ext4    defaults,noauto        0       0
+/dev/mmcblk1p6  /mnt/mmc1/home      ext4    defaults,noauto        0       0

--- a/board/pumpkin-mbm2/rootfs_overlay/etc/fw_env.config
+++ b/board/pumpkin-mbm2/rootfs_overlay/etc/fw_env.config
@@ -10,4 +10,4 @@
 
 # EXT4
 # MTD device name	    Device offset   Env. size	Flash sector size	Number of sectors
-/upgrade/uboot.env      0x0000          0x2800
+/envar/uboot.env      0x0000          0x2800

--- a/board/pumpkin-mbm2/rootfs_overlay/etc/inittab
+++ b/board/pumpkin-mbm2/rootfs_overlay/etc/inittab
@@ -22,16 +22,18 @@
 ::sysinit:/bin/mkdir -p /dev/shm
 
 # Check & clean partitions on mmc1 (internal flash)
-# 2=rootfs, 3=envar, 4=upgrade, 5=home
+# 2=rootfs, 3=envar, 5=upgrade, 6=home
 ::sysinit:/sbin/fsck -p /dev/mmcblk1p2
 ::sysinit:/sbin/fsck -p /dev/mmcblk1p3
-::sysinit:/sbin/fsck -p /dev/mmcblk1p4
+::sysinit:/sbin/fsck -p /dev/mmcblk1p5
+::sysinit:/sbin/fsck -p /dev/mmcblk1p6
 
 # Check & clean partitions on mmc0 (micro-SD card)
-# 2=rootfs, 3=envar, 4=upgrade, 5=home
+# 2=rootfs, 3=envar, 5=upgrade, 6=home
 ::sysinit:/sbin/fsck -p /dev/mmcblk0p2
 ::sysinit:/sbin/fsck -p /dev/mmcblk0p3
-::sysinit:/sbin/fsck -p /dev/mmcblk0p4
+::sysinit:/sbin/fsck -p /dev/mmcblk0p5
+::sysinit:/sbin/fsck -p /dev/mmcblk0p6
 
 # Mount up partitions with data
 ::sysinit:/bin/mount -o remount,rw /

--- a/board/pumpkin-mbm2/rootfs_overlay/usr/sbin/install-os
+++ b/board/pumpkin-mbm2/rootfs_overlay/usr/sbin/install-os
@@ -16,8 +16,8 @@
 #
 # Copy a KubOS image from the SD card to the eMMC
 #
-# LOCO-LINUX NOTE: 
-# 
+# LOCO-LINUX NOTE:
+#
 # This file has been modified from its original version to setup nearly
 # identical disk images on both the mmc0 and mmc1.  After copying the
 # disk image from the micro-SD card in mmc0, it makes a few disk-specific
@@ -29,13 +29,13 @@
 src=
 trg=
 root_prt=2
-last_prt=4
+last_prt=6
 stop_services=false
 update_signature=false
 resize_partition=false
 
 # Define the disk signature for each mmc
-signature_0="\x50\x50\x50\x50" 
+signature_0="\x50\x50\x50\x50"
 signature_1="\x51\x51\x51\x51"
 
 
@@ -43,40 +43,40 @@ signature_1="\x51\x51\x51\x51"
 ### Define the help message        ###
 ######################################
 help_message="
-  Copies the disk image from the input source to the output target 
+  Copies the disk image from the input source to the output target
   mmc.  Optionally performs follow-up filesystem manipulation.
 
   Syntax: ./install-os [-d|h|i|o|r|s]
-  
+
   options:
-   
+
    -i         (required) Input device or image file.  It can be
               the path to a device, e.g. /dev/mmcblk0, or the
-              path to a compressed or uncompressed disk image, 
+              path to a compressed or uncompressed disk image,
               e.g. os.img.gz or os.img.
-  
+
    -o         (required) Output mmc device number:
                 0 = microSD (/dev/mmcblk0)
                 1 = internal eMMC (/dev/mmcblk1)
-                
-   -d         Replace the disk signature in the MBR after copying 
-              the disk image to the target device. The signature 
+
+   -d         Replace the disk signature in the MBR after copying
+              the disk image to the target device. The signature
               used depends on the target device:
                 target=0:  ${signature_0}
                 target=1:  ${signature_1}
 
    -h         Print this help
-   
+
    -r         After installing the disk image on target, this will
-              resize partion ${last_prt} and its filesystem to fill the 
+              resize partion ${last_prt} and its filesystem to fill the
               available space on the target disk.  Partition ${last_prt}
-              is assumed to be the last partition on the disk.   
-              This has only been tested on primary partitions, not 
+              is assumed to be the last partition on the disk.
+              This has only been tested on primary partitions, not
               logical partions.  It assumes parted and resize2fs
               are included in the disk image that was installed
               on the target.
-   
-   -s         Stop all services before copying image to target mmc                
+
+   -s         Stop all services before copying image to target mmc
 
 "
 
@@ -95,16 +95,16 @@ do
             ;;
         o)
             trg=$OPTARG
-            ;;        
+            ;;
         d)
             update_signature=true
             ;;
         h)
             echo "$help_message"
             exit 0
-            ;;    
+            ;;
         r) resize_partition=true
-            ;;     
+            ;;
         s)
             stop_services=true
             ;;
@@ -141,7 +141,7 @@ if [ "${src}" = "/dev/mmcblk${trg}" ]; then
     echo "$help_message" >&2
     exit 1
 fi
-    
+
 # Make sure the user is sure they want to wipe out their mmc
 echo ""
 echo "*** WARNING:"
@@ -173,7 +173,7 @@ if [ ${stop_services} = true ]; then
     sleep 2
 fi
 
-# Unmount anything from target mmc, abort if the mounted root 
+# Unmount anything from target mmc, abort if the mounted root
 # filesystem is on the target mmc (not sure what would happen
 # if we tried to install a disk image over the active root fs).
 echo "install-os: Unmounting target mmc${trg}"
@@ -185,7 +185,7 @@ for i in $(mount -l | grep /dev/mmcblk${trg} | cut -d" " -f3); do
         umount -v $i
     fi
 done
-    
+
 # Copy the input source image to target mmc
 echo "install-os: Copying input image to target mmc${trg}"
 echo "install-os: This process may take 10+ minutes to complete"
@@ -207,40 +207,40 @@ if [[ "${src}" = "/dev/mmcblk"[01] ]]; then
     # Get the source size
     blocks_src=$(cat /sys/class/block/${src##*/}/size)
     echo "install-os: Source size is `expr ${blocks_src} \* ${block_size}` bytes"
-    
+
     # Use the smaller of the target and source sizes
     blocks=$(( blocks_src < blocks_trg ? blocks_src : blocks_trg ))
-    
+
     # Now do the copy
     dd if=${src} count=${blocks} status=noxfer | pv -s `expr ${blocks} \* ${block_size}` | dd of=/dev/mmcblk${trg}
 
 # The input source is a file
 else
-    
+
     case ${src##*.} in
-    
+
         gz|gzip) # Compressed image file
-        
+
             # Too slow to get the uncompressed file size, so don't worry about it
-            echo "install-os: Uncompressed source size is: unknown"     
-            
-            # Now do the copy       
-            gzip -d -c ${src} | pv | dd count=${blocks_trg} iflag=fullblock of=/dev/mmcblk${trg}        
+            echo "install-os: Uncompressed source size is: unknown"
+
+            # Now do the copy
+            gzip -d -c ${src} | pv | dd count=${blocks_trg} iflag=fullblock of=/dev/mmcblk${trg}
             ;;
 
         *) # Uncompressed image file
-        
-            # Get the input size -- this gives the size used by the file on disk, 
+
+            # Get the input size -- this gives the size used by the file on disk,
             # which may be larger than the actual file size, but it is close enough
             # for a reasonable status bar.  Tried wc -c, but was very slow, e.g.
             # 45 seconds / gigabyte on the BeagleBone Black.
             bytes_src=$(du -sb ${src} | cut -f1)
-            echo "install-os:  Source size is: ${bytes_src} bytes"       
-            
-            # We need to use "bc" to do the math because bytes could exceed the shell 
+            echo "install-os:  Source size is: ${bytes_src} bytes"
+
+            # We need to use "bc" to do the math because bytes could exceed the shell
             # math integer size, which is 2^31-1 (2 GB) on the BeagleBone Black.
             bytes=$(echo "if (${bytes_src} < ${bytes_trg}) print ${bytes_src} else print ${bytes_trg}" | bc)
-            
+
             # Now do the copy
             pv -s ${bytes} < ${src} | dd count=${blocks_trg} iflag=fullblock of=/dev/mmcblk${trg}
             ;;
@@ -248,8 +248,8 @@ else
 fi
 
 # OPTION - Set disk signature on target
-# This is a commandline option, but really it should always be done 
-# if the input source is /dev/mmcblk[01], becuase otherwise the source 
+# This is a commandline option, but really it should always be done
+# if the input source is /dev/mmcblk[01], becuase otherwise the source
 # and target devices will have identical partuuid, causing problems.
 if [ ${update_signature} = true ]; then
     echo "install-os: Updating disk signature on target"
@@ -275,17 +275,17 @@ cp ${mnt}/etc/fstab.mmc${trg} ${mnt}/etc/fstab
 
 # OPTION - Resize the final partition to fill the disk
 # Assumes the final partition is a primary partition, not a logical
-# partition.  This generally means it can't be higher than 4. 
+# partition.  This generally means it can't be higher than 4.
 if [ ${resize_partition} = true ]; then
 
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${mnt}/usr/lib"
     export LD_LIBRARY_PATH
-    
+
     # Resize the partition
-    echo "install-os: Resizing /dev/mmcblk${trg}p${last_prt} partition to fill disk"        
+    echo "install-os: Resizing /dev/mmcblk${trg}p${last_prt} partition to fill disk"
     parted_exe="${mnt}/usr/sbin/parted"
-    ${parted_exe} -s /dev/mmcblk${trg} unit % resizepart ${last_prt} 100 
-    
+    ${parted_exe} -s /dev/mmcblk${trg} unit % resizepart ${last_prt} 100
+
     # Resize the filesystem in the partition (assumes ext2, ext3, or ext4)
     # This writes to each byte, I think, so can be very slow for large disks
     echo "install-os: Resizing filesystem to fill /dev/mmcblk${trg}p${last_prt}"
@@ -303,9 +303,3 @@ rmdir ${mnt}
 
 # Done
 echo "install-os: Done.  Recommend rebooting."
-
-
-
-
-
-


### PR DESCRIPTION
adds back the envar partition into genimage.cfg

I've been doing some testing and with this setup the /upgrade partition does not re-corrupt itself randomly on boot.

Would need to update the readme if we want to move forward with this but this does allow for 1 "golden" and 1 new itb file for updates